### PR TITLE
Fix Milton's metadata (affiliation and email)

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -17,8 +17,9 @@ authors:
     twitter: miltondp
     mastodon: miltondp
     mastodon-server: genomic.social
-    email: miltondp@gmail.com
+    email: milton.pividori@cuanschutz.edu
     affiliations:
+      - Department of Biomedical Informatics, University of Colorado School of Medicine, Aurora, CO 80045, USA
       - Department of Genetics, Perelman School of Medicine, University of Pennsylvania, Philadelphia, PA 19104, USA
     funders:
       - The Gordon and Betty Moore Foundation GBMF 4552


### PR DESCRIPTION
These fixes are present in the latex/PDF, but not HTML.